### PR TITLE
Fix inference of arguments in `createTrpcQuery`

### DIFF
--- a/src/lib/trpc.ts
+++ b/src/lib/trpc.ts
@@ -13,9 +13,9 @@ type AppQueries = AppRouter["_def"]["queries"];
 
 type AppQueryKeys = keyof AppQueries & string;
 
-export const createTrpcQuery = (
-  path: AppQueryKeys,
-  ...args: inferHandlerInput<AppQueries[AppQueryKeys]>
+export const createTrpcQuery = <TPath extends AppQueryKeys>(
+  path: TPath,
+  ...args: inferHandlerInput<AppQueries[TPath]>
 ) => {
   const fetchData = async () => {
     return client.query(path, ...args);


### PR DESCRIPTION
Would've started failing once you added another query on the backend